### PR TITLE
Detect for JIRA issue key instead of link

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -8,6 +8,6 @@ mergeable:
     validate:
       - do: description
         must_include:
-          regex: 'https://forto.atlassian.net/\w+/[A-Z][A-Z0-9]+-\d+'
+          regex: '((?<!([A-Z]{1,10})-?)[A-Z]+-\d+)'
           message: 'Must include Jira ticket'
 


### PR DESCRIPTION
Should we instead catch for Jira issue key instead of links?

ABC-123

Accessibility of the issue key should be handled by Github's autolink feature which is handled per repo. Autolink also covers PR title and even commits.

Ref: https://confluence.atlassian.com/stashkb/integrating-with-custom-jira-issue-key-313460921.html